### PR TITLE
Exclude throwsnotcapital rule

### DIFF
--- a/CodeatCodingStandard/ruleset.xml
+++ b/CodeatCodingStandard/ruleset.xml
@@ -45,6 +45,7 @@
         <exclude name="Squiz.Commenting.LongConditionClosingComment.Missing"/>
         <exclude name="Squiz.Commenting.LongConditionClosingComment.Invalid"/>
         <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
+        <exclude name="Squiz.Commenting.FunctionComment.ThrowsNotCapital"/>
         <exclude name="Squiz.Commenting.FunctionCommentThrowTag.Missing"/>
         <exclude name="Squiz.Commenting.FileComment.SpacingAfterOpen"/>
         <exclude name="Squiz.Commenting.FileComment.SpacingAfterComment"/>


### PR DESCRIPTION
The "Squiz.Commenting.FunctionComment.ThrowsNotCapital" (`@throws` phpdoc exception name should start with a Capital letter) is conflicting with "SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation.NonFullyQualifiedClassName" that forces us to use fully qualified name (starting with `\`).